### PR TITLE
Фикс обновления правил fw

### DIFF
--- a/cleantalk.antispam/lib/Cleantalk/Common/Helper.php
+++ b/cleantalk.antispam/lib/Cleantalk/Common/Helper.php
@@ -1348,12 +1348,16 @@ class Helper
     /**
      * Get site url for remote calls.
      *
-     * @return string@important This method can be overloaded in the CMS-based Helper class.
-     *
+     * @return string
+     * @important This method can be overloaded in the CMS-based Helper class.
      */
     private static function getSiteUrl()
     {
-        return ( isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://" . $_SERVER['HTTP_HOST'] . ( isset($_SERVER['SCRIPT_URL'] ) ? $_SERVER['SCRIPT_URL'] : '' );
+        return sprintf(
+            '%s://%s',
+            isset( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http',
+            $_SERVER['HTTP_HOST']
+        );
     }
 
     /**


### PR DESCRIPTION
Здравствуйте,

Можете подтвердить, что `$_SERVER['SCRIPT_URL']` тут не нужен?
Когда я сохранял настройки из админки - этот код выдает урл: https://mysite.ru/bitrix/admin/settings.php?spbc_remote_call_action=sfw_update&plugin_name=apbct&spbc_remote_call_token=7fdd0f46&firewall_updating_id=0&test=test и последующий HTTP запрос на этот урл выдает жопу: https://skr.sh/sRCLgTKXahA.jpg

С исправлением я получаю урл https://mysite.ru/?spbc_remote_call_action=sfw_update&plugin_name=apbct&spbc_remote_call_token=7fdd0f46&firewall_updating_id=0&test=test и "OK" в HTTP запросе

Без этого обновления правил фаервола через сохранение настроек модуля - не работает